### PR TITLE
Add permission table for client-side authorization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ yarnMappings=build.5
 # Fabric
 loaderVersion=0.14.13
 fabricApiVersion=0.73.0+1.19.3
+libGuiVersion=6.5.1+1.19.3

--- a/platforms/fabric/build.gradle.kts
+++ b/platforms/fabric/build.gradle.kts
@@ -36,6 +36,12 @@ loom {
 	}
 }
 
+repositories {
+    maven("https://server.bbkr.space/artifactory/libs-release") {
+        name = "CottonMC"
+    }
+}
+
 dependencies {
     implementation(project(":tensai-common"))
 
@@ -47,6 +53,7 @@ dependencies {
     mappings("net.fabricmc:yarn:${property("minecraftVersion")}+${property("yarnMappings")}:v2")
     modImplementation("net.fabricmc:fabric-loader:${property("loaderVersion")}")
     modImplementation("net.fabricmc.fabric-api:fabric-api:${property("fabricApiVersion")}")
+    modImplementation("io.github.cottonmc:LibGui:${property("libGuiVersion")}")
 }
 
 tasks {

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 PhoMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.phomc.tensai.fabric.client.gui;
+
+import java.util.Map;
+
+import io.github.cottonmc.cotton.gui.client.LightweightGuiDescription;
+import io.github.cottonmc.cotton.gui.widget.WBox;
+import io.github.cottonmc.cotton.gui.widget.WButton;
+import io.github.cottonmc.cotton.gui.widget.WGridPanel;
+import io.github.cottonmc.cotton.gui.widget.WLabel;
+import io.github.cottonmc.cotton.gui.widget.WScrollPanel;
+import io.github.cottonmc.cotton.gui.widget.WToggleButton;
+import io.github.cottonmc.cotton.gui.widget.data.Axis;
+
+import net.minecraft.text.Text;
+
+import dev.phomc.tensai.fabric.client.iam.Permission;
+
+public class PermissionTableGUI extends LightweightGuiDescription {
+	public PermissionTableGUI(Map<Permission, Boolean> map, boolean showFalseOnly, Runnable callback) {
+		WBox container = new WBox(Axis.VERTICAL);
+
+		for (Permission perm : map.keySet()) {
+			if (showFalseOnly && map.get(perm)) {
+				continue;
+			}
+
+			WToggleButton toggleButton = new WToggleButton(perm.getDescription());
+			toggleButton.setOnToggle(on -> {
+				map.put(perm, on);
+			});
+			container.add(toggleButton);
+		}
+
+		WButton button = new WButton(Text.translatable("gui.permissionTable.confirm"));
+		button.setOnClick(callback);
+
+		WGridPanel root = (WGridPanel) rootPanel;
+		root.add(new WLabel(Text.translatable("gui.permissionTable.title")), 0, 0, 12, 1);
+		root.add(new WScrollPanel(container), 0, 1, 12, 8);
+		root.add(button, 0, 10, 12, 3);
+		root.validate(this);
+	}
+}

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/TensaiScreen.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/TensaiScreen.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of tensai, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 PhoMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.phomc.tensai.fabric.client.gui;
+
+import io.github.cottonmc.cotton.gui.GuiDescription;
+import io.github.cottonmc.cotton.gui.client.CottonClientScreen;
+
+public class TensaiScreen extends CottonClientScreen {
+	public TensaiScreen(GuiDescription description) {
+		super(description);
+	}
+}

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/iam/Permission.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/iam/Permission.java
@@ -28,29 +28,30 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 public class Permission {
 	private final Identifier namespace;
 	private final String key;
-	private final String messageTranslationKey;
+	private final Text description;
 	private final Context context;
 	private final boolean persistent;
 
-	public Permission(@NotNull Identifier namespace, @NotNull String key, @NotNull String messageTranslationKey, @NotNull Context context, boolean persistent) {
+	public Permission(@NotNull Identifier namespace, @NotNull String key, @NotNull Text description, @NotNull Context context, boolean persistent) {
 		if (!key.matches("[0-9A-Za-z-_]+")) {
 			throw new IllegalArgumentException("invalid permission key");
 		}
 
 		this.namespace = namespace;
 		this.key = key;
-		this.messageTranslationKey = messageTranslationKey;
+		this.description = description;
 		this.context = context;
 		this.persistent = persistent;
 	}
 
-	public Permission(String namespace, String key, String messageTranslationKey, Context context, boolean persistent) {
-		this(new Identifier(namespace), key, messageTranslationKey, context, persistent);
+	public Permission(String namespace, String key, Text description, Context context, boolean persistent) {
+		this(new Identifier(namespace), key, description, context, persistent);
 	}
 
 	@NotNull
@@ -64,8 +65,8 @@ public class Permission {
 	}
 
 	@NotNull
-	public String getMessageTranslationKey() {
-		return messageTranslationKey;
+	public Text getDescription() {
+		return description;
 	}
 
 	@NotNull
@@ -82,7 +83,7 @@ public class Permission {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		Permission that = (Permission) o;
-		return namespace.equals(that.namespace) && key.equals(that.key) && messageTranslationKey.equals(that.messageTranslationKey) && context == that.context && persistent == that.persistent;
+		return namespace.equals(that.namespace) && key.equals(that.key) && description.equals(that.description) && context == that.context && persistent == that.persistent;
 	}
 
 	@Override

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.InputUtil;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
@@ -55,7 +56,7 @@ public class KeyBindingManager {
 	public static final Identifier KEYBINDING_NAMESPACE = new Identifier(Channel.KEYBINDING.getNamespace());
 	public static final Permission KEY_RECORD_PERMISSION = new Permission(
 			KEYBINDING_NAMESPACE, "record",
-			"gui.permissionPrompt.message.keybinding",
+			Text.translatable("gui.permissionPrompt.message.keybinding"),
 			Permission.Context.SERVER, true
 	);
 	private static final int MIN_INPUT_DELAY = 5;

--- a/platforms/fabric/src/main/resources/assets/tensai/lang/en_us.json
+++ b/platforms/fabric/src/main/resources/assets/tensai/lang/en_us.json
@@ -1,7 +1,9 @@
 {
   "key.categories.tensai": "Tensai Extra Keys",
-  "gui.permissionPrompt.title": "Privacy Protector",
+  "gui.permissionPrompt.title": "Authorization",
   "gui.permissionPrompt.accept": "Accept",
   "gui.permissionPrompt.decline": "Decline",
-  "gui.permissionPrompt.message.keybinding": "Allow the current server to record your key activities?"
+  "gui.permissionPrompt.message.keybinding": "Allow the current server to record your key activities?",
+  "gui.permissionTable.title": "Authorization",
+  "gui.permissionTable.confirm": "Confirm"
 }


### PR DESCRIPTION
Permission table is a set of permissions. The table is shown to allow multi-selection at one time.
Permission table is intended to be used by Keybinding API.