### PR TITLE
Improve keybinding registration

### DIFF
--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
@@ -29,11 +29,13 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a key binding.
+ * Represents a key binding.<br>
+ * A keybinding is listened by the client and its state updates will be broadcast back to the server.
  */
 public class KeyBinding {
 	private final Key key;
 	private final String name;
+	private final boolean enforced;
 
 	/**
 	 * Constructs a keybinding.
@@ -42,8 +44,20 @@ public class KeyBinding {
 	 * @param name Keybinding name
 	 */
 	public KeyBinding(@NotNull Key key, @NotNull String name) {
+		this(key, name, false);
+	}
+
+	/**
+	 * Constructs a keybinding.
+	 *
+	 * @param key  A {@link Key}
+	 * @param name Keybinding name
+	 * @param enforced Whether the keybinding is enforced to be accepted
+	 */
+	public KeyBinding(@NotNull Key key, @NotNull String name, boolean enforced) {
 		this.key = key;
 		this.name = name;
+		this.enforced = enforced;
 	}
 
 	@NotNull
@@ -56,12 +70,16 @@ public class KeyBinding {
 		return name;
 	}
 
+	public boolean isEnforced() {
+		return enforced;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		KeyBinding that = (KeyBinding) o;
-		return key == that.key && name.equals(that.name);
+		return key == that.key && name.equals(that.name) && enforced == that.enforced;
 	}
 
 	@Override
@@ -70,8 +88,19 @@ public class KeyBinding {
 	}
 
 	public enum RegisterStatus {
+		/**
+		 * The client denied the keybinding registration.
+		 */
 		CLIENT_REJECTED,
+
+		/**
+		 * The keybinding was duplicated (collided) with another one.
+		 */
 		KEY_DUPLICATED,
+
+		/**
+		 * The keybinding registration was successful.
+		 */
 		SUCCESS;
 	}
 }

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
@@ -69,10 +69,9 @@ public class KeyBinding {
 		return Objects.hash(key, name);
 	}
 
-	public static class RegisterStatus {
-		public static final byte UNKNOWN = 0;
-		public static final byte CLIENT_REJECTED = 1;
-		public static final byte KEY_DUPLICATED = 2;
-		public static final byte SUCCESS = 127;
+	public enum RegisterStatus {
+		CLIENT_REJECTED,
+		KEY_DUPLICATED,
+		SUCCESS;
 	}
 }

--- a/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/event/KeyRegisterResultEvent.java
+++ b/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/event/KeyRegisterResultEvent.java
@@ -24,11 +24,14 @@
 
 package dev.phomc.tensai.bukkit.event;
 
+import java.util.Map;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
 
-import dev.phomc.tensai.networking.message.c2s.KeyBindingRegisterResponse;
+import dev.phomc.tensai.keybinding.Key;
+import dev.phomc.tensai.keybinding.KeyBinding;
 
 /**
  * This event returns the keybinding registration result.
@@ -36,15 +39,20 @@ import dev.phomc.tensai.networking.message.c2s.KeyBindingRegisterResponse;
  */
 public class KeyRegisterResultEvent extends PlayerEvent {
 	private static final HandlerList handlers = new HandlerList();
-	private final KeyBindingRegisterResponse response;
+	private final Map<Key, KeyBinding.RegisterStatus> status;
 
-	public KeyRegisterResultEvent(Player player, KeyBindingRegisterResponse response) {
+	public KeyRegisterResultEvent(Player player, Map<Key, KeyBinding.RegisterStatus> status) {
 		super(player);
-		this.response = response;
+		this.status = status;
 	}
 
-	public KeyBindingRegisterResponse getResponse() {
-		return this.response;
+	/**
+	 * Gets the status of registered keys.
+	 *
+	 * @return an <b>unmodifiable</b> status map
+	 */
+	public Map<Key, KeyBinding.RegisterStatus> getStatus() {
+		return this.status;
 	}
 
 	@Override

--- a/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/event/KeyStateUpdateEvent.java
+++ b/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/event/KeyStateUpdateEvent.java
@@ -55,7 +55,7 @@ public class KeyStateUpdateEvent extends PlayerEvent {
 	/**
 	 * Returns the current key states.
 	 *
-	 * @return an <b>unmodifiable</b> map representing the key states
+	 * @return a modifiable, shared map
 	 */
 	public Map<Key, KeyState> getKeyStates() {
 		return this.keyStates;

--- a/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/keybinding/KeyBindingMessageSubscriber.java
+++ b/platforms/bukkit/src/main/java/dev/phomc/tensai/bukkit/keybinding/KeyBindingMessageSubscriber.java
@@ -24,6 +24,7 @@
 
 package dev.phomc.tensai.bukkit.keybinding;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.bukkit.Bukkit;
@@ -50,7 +51,7 @@ public class KeyBindingMessageSubscriber extends ServerSubscriber {
 		subscribe(MessageType.KEYBINDING_REGISTER_RESPONSE, (data, sender) -> {
 			KeyBindingRegisterResponse msg = new KeyBindingRegisterResponse();
 			msg.unpack(data);
-			Bukkit.getPluginManager().callEvent(new KeyRegisterResultEvent(((ClientHandleImpl) sender).getPlayer(), msg));
+			Bukkit.getPluginManager().callEvent(new KeyRegisterResultEvent(((ClientHandleImpl) sender).getPlayer(), Collections.unmodifiableMap(msg.getStatus())));
 		});
 
 		subscribe(MessageType.KEYBINDING_STATE_UPDATE, (data, sender) -> {

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
@@ -47,6 +47,7 @@ public class PermissionTableGUI extends LightweightGuiDescription {
 			if (showFalseOnly && map.get(perm)) {
 				continue;
 			}
+
 			map.put(perm, defaultVal);
 
 			WToggleButton toggleButton = new WToggleButton(perm.getDescription());

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/gui/PermissionTableGUI.java
@@ -40,18 +40,20 @@ import net.minecraft.text.Text;
 import dev.phomc.tensai.fabric.client.iam.Permission;
 
 public class PermissionTableGUI extends LightweightGuiDescription {
-	public PermissionTableGUI(Map<Permission, Boolean> map, boolean showFalseOnly, Runnable callback) {
+	public PermissionTableGUI(Map<Permission, Boolean> map, boolean showFalseOnly, boolean defaultVal, Runnable callback) {
 		WBox container = new WBox(Axis.VERTICAL);
 
 		for (Permission perm : map.keySet()) {
 			if (showFalseOnly && map.get(perm)) {
 				continue;
 			}
+			map.put(perm, defaultVal);
 
 			WToggleButton toggleButton = new WToggleButton(perm.getDescription());
 			toggleButton.setOnToggle(on -> {
 				map.put(perm, on);
 			});
+			toggleButton.setToggle(defaultVal);
 			container.add(toggleButton);
 		}
 

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/iam/ClientAuthorizer.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/iam/ClientAuthorizer.java
@@ -124,7 +124,7 @@ public class ClientAuthorizer {
 			return;
 		}
 
-		MinecraftClient.getInstance().setScreen(new TensaiScreen(new PermissionTableGUI(map, true, () -> {
+		MinecraftClient.getInstance().setScreen(new TensaiScreen(new PermissionTableGUI(map, true, true, () -> {
 			for (Permission perm : permissions) {
 				if (map.get(perm)) {
 					forceGrant(perm, serverAddr);

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
@@ -34,7 +34,6 @@ import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.InputUtil;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
@@ -42,7 +41,6 @@ import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
 
 import dev.phomc.tensai.fabric.client.GameOptionProcessor;
 import dev.phomc.tensai.fabric.client.i18n.CustomTranslationStorage;
-import dev.phomc.tensai.fabric.client.iam.Permission;
 import dev.phomc.tensai.fabric.client.mixins.KeyBindingMixin;
 import dev.phomc.tensai.fabric.client.scheduler.tasks.KeyStateCheckTask;
 import dev.phomc.tensai.keybinding.Key;
@@ -54,11 +52,6 @@ import dev.phomc.tensai.server.TensaiServer;
 
 public class KeyBindingManager {
 	public static final Identifier KEYBINDING_NAMESPACE = new Identifier(Channel.KEYBINDING.getNamespace());
-	public static final Permission KEY_RECORD_PERMISSION = new Permission(
-			KEYBINDING_NAMESPACE, "record",
-			Text.translatable("gui.permissionPrompt.message.keybinding"),
-			Permission.Context.SERVER, true
-	);
 	private static final int MIN_INPUT_DELAY = 5;
 	private static final KeyBindingManager INSTANCE = new KeyBindingManager();
 	private List<net.minecraft.client.option.KeyBinding> registeredKeys = new ArrayList<>();
@@ -82,16 +75,8 @@ public class KeyBindingManager {
 		return inputDelay;
 	}
 
-	public boolean testBulkAvailability(@NotNull List<KeyBinding> keymap) {
-		for (KeyBinding keyBinding : keymap) {
-			InputUtil.Key key = getInputKey(keyBinding.getKey());
-
-			if (KeyBindingMixin.getKeyCodeMapping().containsKey(key)) {
-				return false;
-			}
-		}
-
-		return true;
+	public boolean testAvailability(@NotNull Key key) {
+		return KeyBindingMixin.getKeyCodeMapping().containsKey(getInputKey(key));
 	}
 
 	public void initialize(@NotNull List<KeyBinding> keymap, int inputDelay) {

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingManager.java
@@ -76,7 +76,7 @@ public class KeyBindingManager {
 	}
 
 	public boolean testAvailability(@NotNull Key key) {
-		return KeyBindingMixin.getKeyCodeMapping().containsKey(getInputKey(key));
+		return !KeyBindingMixin.getKeyCodeMapping().containsKey(getInputKey(key));
 	}
 
 	public void initialize(@NotNull List<KeyBinding> keymap, int inputDelay) {

--- a/platforms/fabric/src/main/java/dev/phomc/tensai/fabric/event/ServerKeybindingEvents.java
+++ b/platforms/fabric/src/main/java/dev/phomc/tensai/fabric/event/ServerKeybindingEvents.java
@@ -32,8 +32,8 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
 import dev.phomc.tensai.keybinding.Key;
+import dev.phomc.tensai.keybinding.KeyBinding;
 import dev.phomc.tensai.keybinding.KeyState;
-import dev.phomc.tensai.networking.message.c2s.KeyBindingRegisterResponse;
 
 public class ServerKeybindingEvents {
 	public static final Event<ServerKeybindingEvents.KeyRegisterResultEvent> REGISTER_RESULT = EventFactory.createArrayBacked(ServerKeybindingEvents.KeyRegisterResultEvent.class, (listeners) -> (player, result) -> {
@@ -48,13 +48,37 @@ public class ServerKeybindingEvents {
 		}
 	});
 
+	/**
+	 * This event returns the keybinding registration result.
+	 * <b>Note:</b> This event is called asynchronously.
+	 */
 	@FunctionalInterface
 	public interface KeyRegisterResultEvent {
-		void respond(ServerPlayerEntity player, KeyBindingRegisterResponse response);
+		/**
+		 * Called when the status of registered keys is returned.
+		 * @param player the relevant player
+		 * @param status an <b>unmodifiable</b> status map
+		 */
+		void respond(ServerPlayerEntity player, Map<Key, KeyBinding.RegisterStatus> status);
 	}
 
+	/**
+	 * This event is triggered whenever one or more key states is updated.<br>
+	 * <b>Note:</b>
+	 * <ul>
+	 *     <li>The timing may be different from client-side due to connection latency.</li>
+	 *     <li>This event is called asynchronously.</li>
+	 *     <li>No key state update will be sent back to the client.</li>
+	 *     <li>The server-sided key state is shared across mods.</li>
+	 * </ul>
+	 */
 	@FunctionalInterface
 	public interface KeyStateUpdateEvent {
+		/**
+		 * Called when the key states are updated.
+		 * @param player the relevant player
+		 * @param keyStates a modifiable, shared map
+		 */
 		void updateKeyState(ServerPlayerEntity player, Map<Key, KeyState> keyStates);
 	}
 }

--- a/platforms/fabric/src/main/java/dev/phomc/tensai/fabric/keybinding/KeyBindingMessageSubscriber.java
+++ b/platforms/fabric/src/main/java/dev/phomc/tensai/fabric/keybinding/KeyBindingMessageSubscriber.java
@@ -24,6 +24,7 @@
 
 package dev.phomc.tensai.fabric.keybinding;
 
+import java.util.Collections;
 import java.util.Map;
 
 import net.minecraft.server.MinecraftServer;
@@ -52,8 +53,7 @@ public class KeyBindingMessageSubscriber extends ServerSubscriber {
 		subscribe(MessageType.KEYBINDING_REGISTER_RESPONSE, (data, sender) -> {
 			KeyBindingRegisterResponse msg = new KeyBindingRegisterResponse();
 			msg.unpack(data);
-			TensaiFabric.LOGGER.info("Keybinding registration status: {}", msg.getResult());
-			ServerKeybindingEvents.REGISTER_RESULT.invoker().respond(((ServerPlayNetworkAddonMixin) sender).getHandler().player, msg);
+			ServerKeybindingEvents.REGISTER_RESULT.invoker().respond(((ServerPlayNetworkAddonMixin) sender).getHandler().player, Collections.unmodifiableMap(msg.getStatus()));
 		});
 
 		subscribe(MessageType.KEYBINDING_STATE_UPDATE, (data, sender) -> {

--- a/platforms/fabric/src/main/resources/assets/tensai/lang/en_us.json
+++ b/platforms/fabric/src/main/resources/assets/tensai/lang/en_us.json
@@ -3,7 +3,7 @@
   "gui.permissionPrompt.title": "Authorization",
   "gui.permissionPrompt.accept": "Accept",
   "gui.permissionPrompt.decline": "Decline",
-  "gui.permissionPrompt.message.keybinding": "Allow the current server to record your key activities?",
   "gui.permissionTable.title": "Authorization",
-  "gui.permissionTable.confirm": "Confirm"
+  "gui.permissionTable.confirm": "Confirm",
+  "gui.permissionTable.keybinding": "Allows recording %s (%s)"
 }


### PR DESCRIPTION
Implement #20
- Player can select & reject a subset of keybindings
- Response now contains detailed information: which keys were registered successfully, which were rejected, or which were duplicated
