### PR TITLE
KeyBinding flags

### DIFF
--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
@@ -29,13 +29,53 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a key binding.<br>
- * A keybinding is listened by the client and its state updates will be broadcast back to the server.
+ * Represents a key binding which is under control by the Tensai client mod.<br>
+ * A keybinding is listened by the client and its state updates will be broadcast back to the server.<br>
+ * <br>
+ * Note: Key-binding instances may have different name and flags. However, when it comes to play in the client-side,
+ * the only property for distinction is {@link Key}. {@code Key} is used to check for duplication. If there are two
+ * key-binding instances with different names but share the same key, then they are duplicated. Only one of them can be
+ * registered successfully. To learn more about registration, have a look at {@link KeyBindingManager#registerKeyBindings(KeyBinding...)}
  */
 public class KeyBinding {
+	/**
+	 * When {@code FLAG_CAPTURE_ENFORCEMENT} is enabled, if registration fails due to duplication
+	 * ({@link RegisterStatus#KEY_DUPLICATED}), Tensai forcibly listens to the key without the need of registering
+	 * it to the client. In this case, the key will not appear in the settings menu, and thus is not editable.<br>
+	 * An enforced key-binding registration returns {@link RegisterStatus#CAPTURE_ENFORCED}.<br>
+	 * The flag is disabled by default.
+	 */
+	public static final byte FLAG_CAPTURE_ENFORCEMENT = 1;
+
+	/**
+	 * For normal key-bindings which were registered successfully without duplication or the use of
+	 * {@link #FLAG_CAPTURE_ENFORCEMENT}, the {@code FLAG_KEY_EDITABLE} flag permits binding to a different key.<br>
+	 * For example: We have a key-binding {@link Key#KEY_Z} to "Launch a rocket". If this flag is enabled, players can
+	 * bind to a different key such as {@link Key#KEY_X} to do the same operation.<br>
+	 * This is the intended feature in Minecraft, thus the flag is <b>enabled</b> by default.
+	 */
+	public static final byte FLAG_KEY_EDITABLE = 2;
+
+	/**
+	 * When {@code FLAG_OPTIMIZED_STATE_UPDATE} is enabled, key state update is only sent to the server if and
+	 * only if the {@code pressed} property changes. The property can be obtained using {@link KeyState#isPressed()}.<br>
+	 * The flag helps to reduce the workload of exchanging information between client and server. However, the trade-off
+	 * is that the {@code timesPressed} property (obtained using {@link KeyState#getTimesPressed()}) and its relevant
+	 * method {@link KeyState#wasPressed()} will not work.<br>
+	 * The flag is recommended for non-continuous key press. A click, for example, requires a key press (up) and a key
+	 * release while the amount of press times does not matter.<br>
+	 * The flag is disabled by default.
+	 */
+	public static final byte FLAG_OPTIMIZED_STATE_UPDATE = 4;
+
+	/**
+	 * The default flag.
+	 */
+	public static final byte DEFAULT_FLAG = FLAG_KEY_EDITABLE;
+
 	private final Key key;
 	private final String name;
-	private final boolean enforced;
+	private final byte flags;
 
 	/**
 	 * Constructs a keybinding.
@@ -44,20 +84,27 @@ public class KeyBinding {
 	 * @param name Keybinding name
 	 */
 	public KeyBinding(@NotNull Key key, @NotNull String name) {
-		this(key, name, false);
+		this(key, name, DEFAULT_FLAG);
 	}
 
 	/**
-	 * Constructs a keybinding.
-	 *
+	 * Constructs a keybinding with flags.
+	 * <br>
+	 * Example usage:
+	 * <pre>
+	 *     KeyBinding keyBind = new KeyBinding(
+	 *         Key.KEY_X, "Launch rocket",
+	 *         KeyBinding.FLAG_KEY_EDITABLE | KeyBinding.FLAG_OPTIMIZED_STATE_UPDATE
+	 *     );
+	 * </pre>
 	 * @param key  A {@link Key}
 	 * @param name Keybinding name
-	 * @param enforced Whether the keybinding is enforced to be accepted
+	 * @param flags Keybinding flags
 	 */
-	public KeyBinding(@NotNull Key key, @NotNull String name, boolean enforced) {
+	public KeyBinding(@NotNull Key key, @NotNull String name, byte flags) {
 		this.key = key;
 		this.name = name;
-		this.enforced = enforced;
+		this.flags = flags;
 	}
 
 	@NotNull
@@ -70,8 +117,8 @@ public class KeyBinding {
 		return name;
 	}
 
-	public boolean isEnforced() {
-		return enforced;
+	public byte getFlags() {
+		return flags;
 	}
 
 	@Override
@@ -79,11 +126,12 @@ public class KeyBinding {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 		KeyBinding that = (KeyBinding) o;
-		return key == that.key && name.equals(that.name) && enforced == that.enforced;
+		return key == that.key && name.equals(that.name) && flags == that.flags;
 	}
 
 	@Override
 	public int hashCode() {
+		// flags is metadata which should not be included
 		return Objects.hash(key, name);
 	}
 
@@ -94,13 +142,23 @@ public class KeyBinding {
 		CLIENT_REJECTED,
 
 		/**
-		 * The keybinding was duplicated (collided) with another one.
+		 * The keybinding was duplicated with another one registered by Minecraft client or other client-side mods<br>
+		 * A side note: Please distinct this case with "already-registered" error.
+		 * @see KeyBindingManager#registerKeyBindings(KeyBinding...)
 		 */
 		KEY_DUPLICATED,
 
 		/**
+		 * The keybinding was duplicated with another one registered by Minecraft client or other client-side mods<br>
+		 * However, the key state can still be captured thanks to {@link KeyBinding#FLAG_CAPTURE_ENFORCEMENT}.<br>
+		 * A side note: Please distinct this case with "already-registered" error.
+		 * @see KeyBindingManager#registerKeyBindings(KeyBinding...)
+		 */
+		CAPTURE_ENFORCED,
+
+		/**
 		 * The keybinding registration was successful.
 		 */
-		SUCCESS;
+		SUCCESS
 	}
 }

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
@@ -137,7 +137,7 @@ public class KeyBinding {
 
 	public enum RegisterStatus {
 		/**
-		 * The client denied the keybinding registration.
+		 * The client denied key-recording.
 		 */
 		CLIENT_REJECTED,
 
@@ -150,7 +150,7 @@ public class KeyBinding {
 
 		/**
 		 * The keybinding was duplicated with another one registered by Minecraft client or other client-side mods<br>
-		 * However, the key state can still be captured thanks to {@link KeyBinding#FLAG_CAPTURE_ENFORCEMENT}.<br>
+		 * However, {@link KeyBinding#FLAG_CAPTURE_ENFORCEMENT} was set and the client approves key-recording.<br>
 		 * A side note: Please distinct this case with "already-registered" error.
 		 * @see KeyBindingManager#registerKeyBindings(KeyBinding...)
 		 */
@@ -158,6 +158,10 @@ public class KeyBinding {
 
 		/**
 		 * The keybinding registration was successful.
+		 * <ol>
+		 *     <li>There was no key duplication</li>
+		 *     <li>The client approves key-recording</li>
+		 * </ol>
 		 */
 		SUCCESS
 	}

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBinding.java
@@ -29,13 +29,8 @@ import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a key binding which is under control by the Tensai client mod.<br>
- * A keybinding is listened by the client and its state updates will be broadcast back to the server.<br>
- * <br>
- * Note: Key-binding instances may have different name and flags. However, when it comes to play in the client-side,
- * the only property for distinction is {@link Key}. {@code Key} is used to check for duplication. If there are two
- * key-binding instances with different names but share the same key, then they are duplicated. Only one of them can be
- * registered successfully. To learn more about registration, have a look at {@link KeyBindingManager#registerKeyBindings(KeyBinding...)}
+ * Represents a key binding issued by the Tensai client mod.<br>
+ * The keybinding listening to a specific {@link Key} and its state updates will be broadcast back to the server.
  */
 public class KeyBinding {
 	/**
@@ -80,8 +75,8 @@ public class KeyBinding {
 	/**
 	 * Constructs a keybinding.
 	 *
-	 * @param key  A {@link Key}
-	 * @param name Keybinding name
+	 * @param key  The default {@link Key}
+	 * @param name Key-binding name
 	 */
 	public KeyBinding(@NotNull Key key, @NotNull String name) {
 		this(key, name, DEFAULT_FLAG);
@@ -97,9 +92,9 @@ public class KeyBinding {
 	 *         KeyBinding.FLAG_KEY_EDITABLE | KeyBinding.FLAG_OPTIMIZED_STATE_UPDATE
 	 *     );
 	 * </pre>
-	 * @param key  A {@link Key}
-	 * @param name Keybinding name
-	 * @param flags Keybinding flags
+	 * @param key  The default {@link Key}
+	 * @param name Key-binding name
+	 * @param flags Key-binding flags
 	 */
 	public KeyBinding(@NotNull Key key, @NotNull String name, byte flags) {
 		this.key = key;
@@ -129,15 +124,9 @@ public class KeyBinding {
 		return key == that.key && name.equals(that.name) && flags == that.flags;
 	}
 
-	@Override
-	public int hashCode() {
-		// flags is metadata which should not be included
-		return Objects.hash(key, name);
-	}
-
 	public enum RegisterStatus {
 		/**
-		 * The client denied key-recording.
+		 * The key-binding was not conflicted, and might be registered. However, the client rejected the registration.
 		 */
 		CLIENT_REJECTED,
 
@@ -150,7 +139,7 @@ public class KeyBinding {
 
 		/**
 		 * The keybinding was duplicated with another one registered by Minecraft client or other client-side mods<br>
-		 * However, {@link KeyBinding#FLAG_CAPTURE_ENFORCEMENT} was set and the client approves key-recording.<br>
+		 * However, {@link KeyBinding#FLAG_CAPTURE_ENFORCEMENT} was set and the client approved key-recording.<br>
 		 * A side note: Please distinct this case with "already-registered" error.
 		 * @see KeyBindingManager#registerKeyBindings(KeyBinding...)
 		 */
@@ -160,7 +149,7 @@ public class KeyBinding {
 		 * The keybinding registration was successful.
 		 * <ol>
 		 *     <li>There was no key duplication</li>
-		 *     <li>The client approves key-recording</li>
+		 *     <li>The client approved key-recording</li>
 		 * </ol>
 		 */
 		SUCCESS

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBindingManager.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBindingManager.java
@@ -41,6 +41,9 @@ import dev.phomc.tensai.server.client.ClientHandle;
  */
 public class KeyBindingManager {
 	protected final ClientHandle clientHandle;
+
+	// This array stores the states of all listening keys managed by Tensai
+	// This includes: normal & enforced key-bindings
 	protected final KeyState[] keyStates = new KeyState[Key.values().length];
 
 	public KeyBindingManager(@NotNull ClientHandle clientHandle) {

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyBindingManager.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyBindingManager.java
@@ -49,8 +49,20 @@ public class KeyBindingManager {
 
 	/**
 	 * Registers the given key-bindings.<br>
-	 * Already-registered ones are ignored implicitly. This operation will be done asynchronously and the response will
-	 * be returned using the event system.
+	 * This operation will be done asynchronously and the response will be returned using the event system.<br>
+	 * <br>
+	 * <b>Already-registered ones are ignored implicitly. Please distinct this case with duplication:</b>
+	 * <ul>
+	 *    <li>"Already-registered" means there was a successful registration made by whatever server-side mod (plugin)
+	 *    using Tensai. It is possible to listen to its state updates. However, the key-binding behaviour and
+	 *    how the state update will return is defined by the very-first mod (plugin).</li>
+	 *    <li>{@link KeyBinding.RegisterStatus#KEY_DUPLICATED} means the key-binding is conflicted with another one
+	 * 	  registered by the Minecraft client or other client-side mods. Key-capturing is unavailable.</li>
+	 *    <li>{@link KeyBinding.RegisterStatus#CAPTURE_ENFORCED} is the same as {@link KeyBinding.RegisterStatus#KEY_DUPLICATED}
+	 *    except that key-capturing is forced to be operable.</li>
+	 *    <li>To summarize, "already-registered" is a server-side error, while the rest is client-side.</li>
+	 * </ul>
+	 *
 	 * @param keyBindings an array of key-bindings
 	 */
 	public void registerKeyBindings(@NotNull KeyBinding... keyBindings) {

--- a/common/src/main/java/dev/phomc/tensai/keybinding/KeyState.java
+++ b/common/src/main/java/dev/phomc/tensai/keybinding/KeyState.java
@@ -52,9 +52,9 @@ public class KeyState {
 	 * <ul>
 	 *     <li>It increases while the key is pressed down. The number of times is indeterminate.</li>
 	 *     <li>It <b>only decreases</b> when {@link #wasPressed()} is called.</li>
-	 *     <li>It remains unchanged until there is a change to client's screen (client-side behaviour), and it will reset to {@code 0}.</li>
+	 *     <li>It remains unchanged until there is a change to client's screen (client-side behaviour) and will be reset to {@code 0}.</li>
 	 * </ul>
-	 * The range of timesPressed is {@code [0, Short.MAX_VALUE]}
+	 * The range of {@code timesPressed} is {@code [0, Short.MAX_VALUE]}
 	 *
 	 * @return press times
 	 */
@@ -72,7 +72,7 @@ public class KeyState {
 	 *     <li>{@link #isPressed()} denotes whether the key is currently being pressed (down).</li>
 	 *     <li>When {@link #isPressed()} returns {@code false}, the key is released. However, {@link #getTimesPressed()} may still not be reset, so {@code #wasPressed()} possibly returns {@code true}.</li>
 	 * </ul>
-	 * For example:
+	 * Example usage:
 	 * <pre>{@code
 	 * 	while (keyState.wasPressed()) {
 	 * 		player.sendMessage("Key-press event called");

--- a/common/src/main/java/dev/phomc/tensai/networking/message/s2c/KeyBindingRegisterMessage.java
+++ b/common/src/main/java/dev/phomc/tensai/networking/message/s2c/KeyBindingRegisterMessage.java
@@ -58,6 +58,7 @@ public class KeyBindingRegisterMessage extends Message {
 		for (KeyBinding entry : keymap) {
 			stream.writeInt(entry.getKey().getCode());
 			stream.writeUTF(entry.getName());
+			stream.writeByte(entry.getFlags());
 		}
 	}
 
@@ -68,9 +69,10 @@ public class KeyBindingRegisterMessage extends Message {
 		for (int i = 0; i < size; i++) {
 			Key key = Key.lookup(stream.readInt());
 			String str = stream.readUTF();
+			byte flags = stream.readByte();
 
 			if (key != null) {
-				keymap.add(new KeyBinding(key, str));
+				keymap.add(new KeyBinding(key, str, flags));
 			}
 		}
 	}

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingMessageSubscriber.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingMessageSubscriber.java
@@ -93,7 +93,7 @@ public class KeyBindingMessageSubscriber extends ClientSubscriber {
 					continue;
 				}
 
-				if (!KeyBindingManager.getInstance().testAvailability(kb.getKey())) {
+				if (KeyBindingManager.getInstance().isRegistered(kb.getKey())) {
 					status.put(kb.getKey(), KeyBinding.RegisterStatus.KEY_DUPLICATED);
 					continue;
 				}

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingMessageSubscriber.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/keybinding/KeyBindingMessageSubscriber.java
@@ -68,21 +68,34 @@ public class KeyBindingMessageSubscriber extends ClientSubscriber {
 
 	private void prompt(KeyBindingRegisterMessage msg, PacketSender sender) {
 		String server = Objects.requireNonNull(((ClientPlayNetworkAddonMixin) sender).getHandler().getServerInfo()).address;
+
+		// registration status of all key-binding
+		Map<Key, KeyBinding.RegisterStatus> status = new HashMap<>();
+
+		// only available and enforced keys are asked for permission and stored in this map
 		Map<Permission, KeyBinding> mapping = new HashMap<>();
+
 		Set<Permission> set = msg.getKeymap().stream()
-				.map(keyBinding -> {
+				.filter(kb -> {
+					if (KeyBindingManager.isRegistered(kb.getKey()) && (kb.getFlags() & KeyBinding.FLAG_CAPTURE_ENFORCEMENT) == 0) {
+						status.put(kb.getKey(), KeyBinding.RegisterStatus.KEY_DUPLICATED);
+						return false;
+					}
+
+					return true;
+				})
+				.map(kb -> {
 					Permission perm = new Permission(
-							KeyBindingManager.KEYBINDING_NAMESPACE, keyBinding.getKey().name(),
-							Text.translatable("gui.permissionTable.keybinding", keyBinding.getKey().name(), keyBinding.getName()),
+							KeyBindingManager.KEYBINDING_NAMESPACE, kb.getKey().name(),
+							Text.translatable("gui.permissionTable.keybinding", kb.getKey().name(), kb.getName()),
 							Permission.Context.SERVER,
 							true
 					);
-					mapping.put(perm, keyBinding);
+					mapping.put(perm, kb);
 					return perm;
 				}).collect(Collectors.toSet());
 
 		TensaiFabricClient.getInstance().getClientAuthorizer().tryGrantMulti(set, server, table -> {
-			Map<Key, KeyBinding.RegisterStatus> status = new HashMap<>();
 			List<KeyBinding> keylist = new ArrayList<>();
 
 			for (Map.Entry<Permission, Boolean> entry : table.entrySet()) {
@@ -93,12 +106,12 @@ public class KeyBindingMessageSubscriber extends ClientSubscriber {
 					continue;
 				}
 
-				if (KeyBindingManager.getInstance().isRegistered(kb.getKey())) {
-					status.put(kb.getKey(), KeyBinding.RegisterStatus.KEY_DUPLICATED);
-					continue;
+				if ((kb.getFlags() & KeyBinding.FLAG_CAPTURE_ENFORCEMENT) > 0) {
+					status.put(kb.getKey(), KeyBinding.RegisterStatus.CAPTURE_ENFORCED);
+				} else {
+					status.put(kb.getKey(), KeyBinding.RegisterStatus.SUCCESS);
 				}
 
-				status.put(kb.getKey(), KeyBinding.RegisterStatus.SUCCESS);
 				keylist.add(kb);
 			}
 

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/mixins/GameOptionsMixin.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/mixins/GameOptionsMixin.java
@@ -27,9 +27,6 @@ package dev.phomc.tensai.fabric.client.mixins;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-
-import dev.phomc.tensai.fabric.client.keybinding.KeyBindingManager;
-
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -41,6 +38,7 @@ import net.minecraft.client.option.KeyBinding;
 import net.fabricmc.fabric.impl.client.keybinding.KeyBindingRegistryImpl;
 
 import dev.phomc.tensai.fabric.client.GameOptionProcessor;
+import dev.phomc.tensai.fabric.client.keybinding.KeyBindingManager;
 
 @Mixin(GameOptions.class)
 public class GameOptionsMixin implements GameOptionProcessor {

--- a/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/mixins/GameOptionsMixin.java
+++ b/platforms/fabric/src/client/java/dev/phomc/tensai/fabric/client/mixins/GameOptionsMixin.java
@@ -27,6 +27,9 @@ package dev.phomc.tensai.fabric.client.mixins;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+
+import dev.phomc.tensai.fabric.client.keybinding.KeyBindingManager;
+
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -48,7 +51,9 @@ public class GameOptionsMixin implements GameOptionProcessor {
 
 	@Override
 	public void reprocessKeys() {
-		allKeys = KeyBindingRegistryImpl.process(allKeys);
+		List<KeyBinding> newKeysAll = Lists.newArrayList(KeyBindingRegistryImpl.process(allKeys));
+		newKeysAll.removeAll(KeyBindingManager.getInstance().getNonEditableKeyBindings());
+		allKeys = newKeysAll.toArray(new KeyBinding[0]);
 	}
 
 	@Override

--- a/specs/Keybinding API.md
+++ b/specs/Keybinding API.md
@@ -20,7 +20,7 @@ The keybinding API must meet the following requirements:
 - Release (Press Up): No longer hold down a key
     + Mouse Up: a mouse button is released
     + Key Up: a key is released
-- A click = Mouse Down + Mouse Up
+- A click = N mouse down + 1 mouse up
 - GLFW Key code: A number identifier tagged to a key (assigned by GLFW)
     + The code of a keyboard key and a mouse button can be identical
     + The key category is used to distinguish key types
@@ -48,6 +48,7 @@ The keybinding API must meet the following requirements:
 For each keybinding entry:
     [int]   Key code
     [UTF]   Key name
+    [byte]  Key flags
 ```
 
 ### (Server-bound) Registration Response
@@ -62,11 +63,6 @@ For each keybinding entry:
     [byte]   Key registration status
 ```
 
-Status:
-- 0: client rejected
-- 1: key duplicated
-- 2: success
-
 ### (Server-bound) Key State Update
 - The client holds a table of key states. Every tick, if a change in that table is detected, a "key state update" packet is sent. In other words, all key states in an interval are contained in a single packet. The client only sends key states that have been recently updated.
 
@@ -77,4 +73,50 @@ For each updated keybinding entry:
     [int]     Key code
     [short]   Pressed times
     [bool]    Is pressed
+    [byte]    Dirty
 ```
+
+## Key Flags
+(Copied from Javadocs)
+
+### Capture Enforcement
+- When FLAG_CAPTURE_ENFORCEMENT is enabled, if registration fails due to duplication (KeyBinding.RegisterStatus.KEY_DUPLICATED), Tensai forcibly listens to the key without the need of registering it to the client. In this case, the key will not appear in the settings menu, and thus is not editable.
+- An enforced key-binding registration returns KeyBinding.RegisterStatus.CAPTURE_ENFORCED.
+- The flag is disabled by default.
+
+### Editable
+- For normal key-bindings which were registered successfully without duplication or the use of FLAG_CAPTURE_ENFORCEMENT, the FLAG_KEY_EDITABLE flag permits binding to a different key. 
+- For example: We have a key-binding Key.KEY_Z to "Launch a rocket". If this flag is enabled, players can bind to a different key such as Key.KEY_X to do the same operation. 
+- This is the intended feature in Minecraft, thus the flag is enabled by default.
+
+### Optimized State Update
+- When FLAG_OPTIMIZED_STATE_UPDATE is enabled, key state update is only sent to the server if and only if the pressed property changes. The property can be obtained using KeyState.isPressed(). 
+- The flag helps to reduce the workload of exchanging information between client and server. However, the trade-off is that the timesPressed property (obtained using KeyState.getTimesPressed()) and its relevant method KeyState.wasPressed() will not work. 
+- The flag is recommended for non-continuous key press. A click, for example, requires a key press (up) and a key release while the amount of press times does not matter. 
+- The flag is disabled by default.
+
+## Key Registration Response
+
+### Already-registered
+- "Already-registered" means there was a successful registration made by whatever server-side mod (plugin) using Tensai. It is possible to listen to its state updates. However, the key-binding behaviour and how the state update will return is defined by the very-first mod (plugin).
+- This is the only server-side error
+
+### Status 0: Client rejected
+The keybinding is not conflicted, and might be successfully registered. However, the client rejects the registration of the key.
+
+### Status 1: Key duplicated
+KeyBinding.RegisterStatus.KEY_DUPLICATED means the key-binding is conflicted with another one registered by the Minecraft client or other client-side mods. Key-capturing is unavailable.
+
+### Status 2: Key enforced
+KeyBinding.RegisterStatus.CAPTURE_ENFORCED is the same as KeyBinding.RegisterStatus.KEY_DUPLICATED except that key-capturing is forced to be operable.
+
+### Status 3: Success
+The keybinding is successfully registered in client-side.
+
+## Implementation
+
+Tensai utilizes Minecraft's key-binding system, so the registration process also follows the system's rules:
+- Minecraft, Tensai and other client-side mods can register key-binding at initialization phase
+- The key-bind's default key must not be registered before
+- A key-binding can be configured in the settings menu. Duplicated ones are shown in red, and the one differ from its default key is not usable.
+- Minecraft preserves a few keys. Only available ones can be registered using Fabric API

--- a/specs/Keybinding API.md
+++ b/specs/Keybinding API.md
@@ -9,27 +9,209 @@ The keybinding API must meet the following requirements:
 - Allows the server to listen to key events from client
 - The server has no ability to modify client's key-states
 - Key capture must be under player control
-- Data transfer must be secure and reliable
+- Data transfer must be lightweight, secure and reliable
 
 ## Terminology
 
-- Key: In Tensai, a key can be either a keyboard key or a mouse button
+### 1. Input type
+Defines the source of input (input peripheral device). There are two notable types of input:
+1. "Keyboard" keys
+2. Mouse buttons
+
+### 2. Input code
+An input is assigned a number identifier. They are more convenient to work in programming than using their translated names.<br>
+For example: The `Enter` key has a key code of `13` <br>
+Input code is the same in almost environment: web, Minecraft, other OpenGL applications, etc
+
+### 3. Tensai key
+Normally, to identify an input, we need two parameters:
+- Input type
+- Input code
+
+For convenience, in Tensai, keyboard input and mouse input is merged into the same category called `Key` with the following convention:
+- The first `1 << 9` keys are keyboard input
+- The rest is mouse input
+
+**Ambiguous:** The term `Key` can be ambiguous: whether it refers to `Keyboard key` or `(Tensai) Key`. Therefore, from now on, we agree that `Key` means `(Tensai) key` referring either keyboard input or mouse input.
+<br>
+
+**Note:** Key is not identified by case. For example, key `A` or `a` has the same code `65`. However, two characters `A` and `a` are different:
+- `A` has a `char code` of 65, typed by the key combination `Shift + A` (Caps lock off), or `A` (Caps lock on)
+- `a` has a `char code` of 97, typed by the `A` key (Caps lock off), or `Shift + A` (Caps lock on)<br>
+
+### 4. Events
+
+There are two main input events:
 - Press (Press Down): To hold down a key
-    + Mouse Down: a mouse button is pressed
-    + Key Down: a key is pressed
 - Release (Press Up): No longer hold down a key
-    + Mouse Up: a mouse button is released
-    + Key Up: a key is released
-- A click = N mouse down + 1 mouse up
-- GLFW Key code: A number identifier tagged to a key (assigned by GLFW)
-    + The code of a keyboard key and a mouse button can be identical
-    + The key category is used to distinguish key types
-- (Tensai) Key code: A number identifier tagged to a key (assigned by Tensai)
-    + The code of a keyboard key and a mouse button is always different
-    + Tensai does not use key category
-    + The first `1 << 9` elements of the list belong to keyboard keys
-    + The rest belongs to mouse buttons
-- Key combo (Key combination): Consists of multiple keys
+
+A typical user input looks like this: ``Press Press Press Press ... Press Release``. When the user holds down a key, multiple `press` events will be sent. The number of times is non-deterministic. This ends with a single `release` event when the key is released.
+- For example, a click is `N mouse press + 1 mouse release`. We mostly do not care about how many `press` are there. A key can be hold down for a long time until it is pressed up.
+- The number of `press` is used in typing. If there are 5 `press`, the user is typing 5 identical characters. A `sensitivity` option may exist, so 5 `press` may make up only 3 characters.
+
+### 5. Key-binding
+Key-binding is a named button which binds to a specific key. For example, we can define:
+```
+"Open Inventory" --> Key E (Code = 69)
+"Attack" ----------> Left Mouse Button (Code = 1 << 9)
+```
+
+Key-binding is editable according to user preference.
+
+```
+"Open Inventory" (default: E) -----> ESC
+"Close Inventory" (default: ESC) --> E
+```
+
+Since a key-binding can bind to a different key than default. It is possible that we may run into a collision (duplication) in which two different key-bindings try to bind to the same key. In Minecraft, the key-binding which has the default key identical to the conflicted key gains prioritized, while the other key-binding is unbounded until the player resolves the issue.
+
+```
+"Open Inventory" (default: E) --------> E (prioritized)
+"Close Inventory" (default: ESC) -------↑ (collided)
+```
+
+## Tensai Key-binding
+This section discusses the Keybinding API features in details.
+
+### 1. Capture methods
+Currently, Tensai offers two methods of key-capturing:
+- Normal: Tensai utilizes the Fabric API and Minecraft system to register a key-binding. The key-binding works exactly what it is in Minecraft, and it can be editable by the player.
+- Capture Enforcement: Enforces capturing the state of a specific key when we can not register a key-binding normally due to collision. We use an already-registered key-binding for reference. The key-binding can be variable (since a key can be binded by different key-bindings, but only one of them at once)
+
+### 2. KeyBinding
+
+For convenience, both methods use the same `KeyBinding` structure:
+```
+Name: The name of the key-binding
+Default key: The key to bind by default
+Flags: Key-binding flags (see below)
+```
+
+<br>**Identification**
+- The default key is used to identify keybinding since it is constant
+- It is impossible to have two key-binding with the same default key
+
+### 3. Key State
+
+`KeyState` structure is used to store the current state of a key-binding.
+
+```
+TimesPressed: How many times the event `pressed` occurred (Non-negative)
+Pressed: Whether the key-binding is current pressed
+Dirty: A mask value to keep track of which properties were changed
+  - Bit 0 for TimesPressed
+  - Bit 1 for Pressed
+```
+
+#### "wasPressed" and "isPressed"
+
+In the current implementation, there are two methods `isPressed` and `wasPressed`. They are preserved to be the same as in Fabric environment. 
+- `isPressed` returns the `pressed` property. It describes whether the key is currently pressed.
+- `wasPressed` checks whether `TimesPressed` is positive and decrease it by `1`
+
+So how they work exactly?
+- Every tick, Minecraft polls the `press` event using GLFW. A batch may have 1 - 3 `press` or more.
+- For example, while the key `A` is pressed, multiple `press` will be counted to `TimesPressed` property. The `pressed` property, however, is a boolean. It is `true` when a `press` event is received, and is `false` when a `release` event happens.
+- `isPressed`, as its name stated, shows the current state of the key; while `wasPressed` may contain the count of past `press`.
+- `isPressed` is recommended for non-continuous key check, while `wasPressed` is suitable for typing check.
+
+#### Resetting
+In Minecraft, the key state is cleaned when a GUI is opened.
+
+#### State Update
+- Tensai is responsible to send state updates from client to server. It is a unidirectional synchronization. No state update is sent back to the client.
+- State updates are batched in a single message (see details below)
+
+#### Conflict
+A conflict can occur if both key-bindings issued by Tensai listening to the same key. Assume we have:
+  - A key-binding `#0` with default key `A` managed by Tensai
+  - A key-binding `#1` with default key `B` created by whoever
+
+Then, we attempt to register another one `#2` with default key `B`. Since the `B` is already occupied, we have to enable `Capture Enforcement` to listen to the `B` key.<br>
+At this point, we have:
+```
+Key-binding  | Key    | Method    | Reference
+#0 -----------> A       Normal
+#1 -----------> B       Normal
+#2 -------------↑       Enforced      #1
+```
+
+Then, we swap the key of the two normal key-binding. Since we have an enforced key-binding listening to `B`, we have to re-update the reference
+```
+Key-binding  | Key    | Method    | Reference
+#0 -----------> B <--   Normal
+#1 -----------> A   |   Normal
+#2 -----------------|   Enforced      #0
+```
+At this stage, both `#0` and `#2` managed by Tensai is listening to the same key `B`.<br>
+<br>
+**We agree that:** If multiple key-bindings managed by Tensai are listening to the same key, we ignore all enforced key-binding.
+
+
+### 4. Key flags
+The key flag controls how a key-binding should behave in
+client-side.
+
+1. Capture Enforcement
+   - When FLAG_CAPTURE_ENFORCEMENT is enabled, if registration fails due to duplication (KeyBinding.RegisterStatus.KEY_DUPLICATED), Tensai forcibly listens to the key without the need of registering it to the client. In this case, the key will not appear in the settings menu, and thus is not editable.
+   - An enforced key-binding registration returns KeyBinding.RegisterStatus.CAPTURE_ENFORCED.
+   - The flag is disabled by default.
+2. Editable
+   - For normal key-bindings which were registered successfully without duplication or the use of FLAG_CAPTURE_ENFORCEMENT, the FLAG_KEY_EDITABLE flag permits binding to a different key.
+   - For example: We have a key-binding Key.KEY_Z to "Launch a rocket". If this flag is enabled, players can bind to a different key such as Key.KEY_X to do the same operation.
+   - This is the intended feature in Minecraft, thus the flag is enabled by default.
+3. Optimized State Update
+   - When FLAG_OPTIMIZED_STATE_UPDATE is enabled, key state update is only sent to the server if and only if the pressed property changes. The property can be obtained using KeyState.isPressed().
+   - The flag helps to reduce the workload of exchanging information between client and server. However, the trade-off is that the timesPressed property (obtained using KeyState.getTimesPressed()) and its relevant method KeyState.wasPressed() will not work.
+   - The flag is recommended for non-continuous key press. A click, for example, requires a key press (up) and a key release while the amount of press times does not matter.
+   - The flag is disabled by default.
+
+_(Copied from Javadocs)_
+<br>
+
+**Illustration table:**
+
+|         	          |          Normal                   	           |                       Enforced                                         	                        |
+|:------------------:|:---------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
+| How to register? 	 | Register normally and no collision happened 	 | Flag "Capture Enforcement" required.<br> Attempted normal registration but collision happened 	 |
+|   Be named     	   |   ✓<br>(Appears in settings menu)        	    |        ✓<br>(However, has no functionality currently)                                 	         |
+| Set default key 	  |            ✓                     	            |                  ✓<br>(Remains permanently)                                  	                  |
+|   Edit key     	   |  ✓<br>(Flag "Editable" must be enabled)    	  |                         ✗                                             	                         |
+|   Reference    	   |            ✗                     	            |      ✓<br>(Need a dynamic reference to an existing key-binding)                         	       |
+
+### Registration
+
+The workflow of registration as follows:
+
+1. First, in server-side, checks whether the key-binding is already registered.
+   - If `true`: returns `Already-registered`
+   - If `false`: continue to step 2
+2. In client-side, checks if the key-binding is already registered
+   - If `true`: continue to step 3
+   - If `false`: continue to step 4
+3. Checks whether the key-binding is flagged `Capture Enforcement`
+   - If `true`: continue to step 4
+   - If `false`: returns `Key duplicated`
+4. Asks the player for permission
+    - Can be bypassed if the permission is already granted
+    - If `true`: continues to step 5
+    - If `false`: returns `Client rejected`
+5. Registers the key-binding
+    - Returns `Success` for normal registration
+    - Returns `Key enforced` for enforced registration
+
+**List of registration response:**
+1. Already-registered
+   - "Already-registered" means there was a successful registration made by whatever server-side mod (plugin) using Tensai. It is possible to listen to its state updates. However, the key-binding behaviour and how the state update will return is defined by the very-first mod (plugin).
+   - This is the only server-side error
+2. Status = 0: Client rejected
+   - The keybinding is not conflicted, and might be successfully registered. However, the client rejects the registration of the key.
+3. Status = 1: Key duplicated
+   - KeyBinding.RegisterStatus.KEY_DUPLICATED means the key-binding is conflicted with another one registered by the Minecraft client or other client-side mods. Key-capturing is unavailable.
+4. Status = 2: Key enforced
+   - KeyBinding.RegisterStatus.CAPTURE_ENFORCED is the same as KeyBinding.RegisterStatus.KEY_DUPLICATED except that key-capturing is forced to be operable.
+5. Status = 3: Success
+   - The keybinding is successfully registered in client-side.
 
 ## Networking
 
@@ -39,84 +221,38 @@ The keybinding API must meet the following requirements:
 - 3: Key State Update
 
 ### (Client-bound) Registration Request
-- After the player joins the server successfully, the server will send a "keybinding registration" request back to the client.<br>
-- It is **important** for 3rd plugins to register keybinding at startup (before anyone joins the server)
+- Registration request can be sent any time during play phase
 
 ```
 [byte]  PID
 [int]   Size of keybinding map
 For each keybinding entry:
-    [int]   Key code
-    [UTF]   Key name
-    [byte]  Key flags
+    [int]   Default key code
+    [UTF]   Key-binding name
+    [byte]  Key-binding flags
 ```
 
 ### (Server-bound) Registration Response
-- The client has full control of whether to accept or reject keybinding. A prompt is opened to ask the player's decision.
-- After that, the client will return the result to the server.
+- The client has full control of whether to accept or reject a keybinding. A prompt is opened to ask the player's decision.
+- The client must return the result to server immediately.
 
 ```
 [byte]   PID
 [int]    Size of keybinding map
 For each keybinding entry:
-    [int]    Key code
+    [int]    Default key code
     [byte]   Key registration status
 ```
 
 ### (Server-bound) Key State Update
-- The client holds a table of key states. Every tick, if a change in that table is detected, a "key state update" packet is sent. In other words, all key states in an interval are contained in a single packet. The client only sends key states that have been recently updated.
+- The client holds a table of key states. Every tick, if a change in that table is detected, a "key state update" packet is sent. In other words, all key states in an interval are contained in a single packet. The client must send only key states that have been recently updated.
 
 ```
 [byte]  PID
 [int]   Number of updated key states
 For each updated keybinding entry:
-    [int]     Key code
+    [int]     Default key code
     [short]   Pressed times
     [bool]    Is pressed
-    [byte]    Dirty
+    [byte]    Dirty mask
 ```
-
-## Key Flags
-(Copied from Javadocs)
-
-### Capture Enforcement
-- When FLAG_CAPTURE_ENFORCEMENT is enabled, if registration fails due to duplication (KeyBinding.RegisterStatus.KEY_DUPLICATED), Tensai forcibly listens to the key without the need of registering it to the client. In this case, the key will not appear in the settings menu, and thus is not editable.
-- An enforced key-binding registration returns KeyBinding.RegisterStatus.CAPTURE_ENFORCED.
-- The flag is disabled by default.
-
-### Editable
-- For normal key-bindings which were registered successfully without duplication or the use of FLAG_CAPTURE_ENFORCEMENT, the FLAG_KEY_EDITABLE flag permits binding to a different key. 
-- For example: We have a key-binding Key.KEY_Z to "Launch a rocket". If this flag is enabled, players can bind to a different key such as Key.KEY_X to do the same operation. 
-- This is the intended feature in Minecraft, thus the flag is enabled by default.
-
-### Optimized State Update
-- When FLAG_OPTIMIZED_STATE_UPDATE is enabled, key state update is only sent to the server if and only if the pressed property changes. The property can be obtained using KeyState.isPressed(). 
-- The flag helps to reduce the workload of exchanging information between client and server. However, the trade-off is that the timesPressed property (obtained using KeyState.getTimesPressed()) and its relevant method KeyState.wasPressed() will not work. 
-- The flag is recommended for non-continuous key press. A click, for example, requires a key press (up) and a key release while the amount of press times does not matter. 
-- The flag is disabled by default.
-
-## Key Registration Response
-
-### Already-registered
-- "Already-registered" means there was a successful registration made by whatever server-side mod (plugin) using Tensai. It is possible to listen to its state updates. However, the key-binding behaviour and how the state update will return is defined by the very-first mod (plugin).
-- This is the only server-side error
-
-### Status 0: Client rejected
-The keybinding is not conflicted, and might be successfully registered. However, the client rejects the registration of the key.
-
-### Status 1: Key duplicated
-KeyBinding.RegisterStatus.KEY_DUPLICATED means the key-binding is conflicted with another one registered by the Minecraft client or other client-side mods. Key-capturing is unavailable.
-
-### Status 2: Key enforced
-KeyBinding.RegisterStatus.CAPTURE_ENFORCED is the same as KeyBinding.RegisterStatus.KEY_DUPLICATED except that key-capturing is forced to be operable.
-
-### Status 3: Success
-The keybinding is successfully registered in client-side.
-
-## Implementation
-
-Tensai utilizes Minecraft's key-binding system, so the registration process also follows the system's rules:
-- Minecraft, Tensai and other client-side mods can register key-binding at initialization phase
-- The key-bind's default key must not be registered before
-- A key-binding can be configured in the settings menu. Duplicated ones are shown in red, and the one differ from its default key is not usable.
-- Minecraft preserves a few keys. Only available ones can be registered using Fabric API


### PR DESCRIPTION
KeyBinding flags control how client-side Tensai mod should work with a keybinding.

**1. Capture Enforcement**
With enforced mode, if Minecraft or another mod already registers a key, its state change can still be captured. No client-side actions will be cancelled.

**2. Editable**
This property permits editing a key-binding.

**3. Optimized State Update**
In optimized mode, a state update is sent if and only if the isPressed property changes
This mode helps improve performance by reducing number of packets

This closes #43 and fixes #39 